### PR TITLE
Fix duplicate word in FreeRTOSConfig.h

### DIFF
--- a/source/tutorials/tutorial_5/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_5/include/FreeRTOSConfig.h
@@ -90,7 +90,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
There was a typo in the comment, resulting in a duplicate word "some some" in the comment above `configAssert( x )`'s definition. I removed one "some" out of the comment, to make it grammatically correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
