### PR TITLE
Fix all duplicate words in FreeRTOSConfig.h

### DIFF
--- a/source/tutorials/tutorial_1/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_1/include/FreeRTOSConfig.h
@@ -89,7 +89,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_10/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_10/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_11/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_11/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_12/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_12/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_13/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_13/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_14/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_14/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_15/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_15/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_16/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_16/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_17/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_17/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_18/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_18/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_19/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_19/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_2/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_2/include/FreeRTOSConfig.h
@@ -89,7 +89,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_20/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_20/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_21/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_21/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_3/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_3/include/FreeRTOSConfig.h
@@ -90,7 +90,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_4/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_4/include/FreeRTOSConfig.h
@@ -90,7 +90,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_5/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_5/include/FreeRTOSConfig.h
@@ -90,7 +90,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_6/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_6/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_7/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_7/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_8/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_8/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 

--- a/source/tutorials/tutorial_9/include/FreeRTOSConfig.h
+++ b/source/tutorials/tutorial_9/include/FreeRTOSConfig.h
@@ -91,7 +91,7 @@
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro.  Don't define
  * configASSERT() when performing code coverage tests though, as it is not
- * intended to asserts() to fail, some some code is intended not to run if no
+ * intended to asserts() to fail, some code is intended not to run if no
  * errors are present. */
 #define configASSERT( x )               if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
I did not realize that every tutorial's config file has the same type where the word "same" appears twice. I have removed all duplicated in every tutorial folder in this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
